### PR TITLE
Fixed 404 broken link to Wapoo SVG

### DIFF
--- a/faq_en.html
+++ b/faq_en.html
@@ -41,7 +41,7 @@
                 </h2>
 
                 <ul>
-                    <li><a href="http://jawordpressorg.github.io/wapuu/wapuu_original.svg">wapuu_original.svg</a>
+                    <li><a href="http://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.svg">wapuu_original.svg</a>
                       <ul>
                           <li>(Also it is included in this GitHub repository)</li>
                       </ul>


### PR DESCRIPTION
Wapoo on english FAQ page is 404 not found, fixed link.
