### PR TITLE
Update Fork me links and use HTTPS

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -33,7 +33,7 @@
                 <p>「わぷー (Wapuu)」は、ja.wordpress.org の公式キャラクターです。</p>
 
                 <ul>
-                    <li><a href="http://ja.wordpress.org/about-wp-ja/wapuu/">WordPress › 日本語 « 日本公式キャラクター「わぷー」</a></li>
+                    <li><a href="https://ja.wordpress.org/about-wp-ja/wapuu/">WordPress › 日本語 « 日本公式キャラクター「わぷー」</a></li>
                 </ul>
 
                 <h2>
@@ -41,13 +41,13 @@
                 </h2>
 
                 <ul>
-                    <li>SVG 形式ファイル: <a href="http://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.svg">wapuu_original.svg</a>
+                    <li>SVG 形式ファイル: <a href="https://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.svg">wapuu_original.svg</a>
                         <ul>
                             <li>(もしくはこのサイトの GitHub リポジトリにも含まれています)</li>
                         </ul>
                         </li>
-                    <li><a href="http://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.png">PNG 画像（338×372 px）</a></li>
-                    <li><a href="http://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.pdf">ベクター形式 PDF ファイル</a></li>
+                    <li><a href="https://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.png">PNG 画像（338×372 px）</a></li>
+                    <li><a href="https://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.pdf">ベクター形式 PDF ファイル</a></li>
                 </ul>
                 <p>上記ファイルがカスタマイズしにくい場合は、最初のバージョンの画像ファイルを試すといいかもしれません。</p>
                 <ul>
@@ -161,7 +161,7 @@
         <div id="footer_wrap" class="outer">
             <footer class="inner">
                 <p class="copyright">Wapuu maintained by <a href="https://github.com/jawordpressorg">jawordpressorg</a></p>
-                <p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>
+                <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
             </footer>
         </div>
 

--- a/faq.html
+++ b/faq.html
@@ -13,7 +13,7 @@
     </head>
 
     <body>
-        <a href="http://jawordpressorg.github.io/wapuu/"><img style="position: absolute; top: 0; right: 0; border: 0; padding: 0; margin: 0; box-shadow: none;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+        <a href="https://github.com/jawordpressorg/wapuu/"><img style="position: absolute; top: 0; right: 0; border: 0; padding: 0; margin: 0; box-shadow: none;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
         <!-- HEADER -->
         <div id="header_wrap" class="outer">
             <header class="inner">

--- a/faq_en.html
+++ b/faq_en.html
@@ -33,7 +33,7 @@
                 <p>わぷー（Wapuu) is the official mascot of ja.wordpress.org.</p>
 
                 <ul>
-                    <li><a href="http://ja.wordpress.org/about-wp-ja/wapuu/">WordPress › Japanese « Japanese team's Official Mascot "Wapuu"</a></li>
+                    <li><a href="https://ja.wordpress.org/about-wp-ja/wapuu/">WordPress › Japanese « Japanese team's Official Mascot "Wapuu"</a></li>
                 </ul>
 
                 <h2>
@@ -41,13 +41,13 @@
                 </h2>
 
                 <ul>
-                    <li><a href="http://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.svg">wapuu_original.svg</a>
+                    <li><a href="https://jawordpressorg.github.io/wapuu/wapuu-original/wapuu-original.svg">wapuu_original.svg</a>
                       <ul>
                           <li>(Also it is included in this GitHub repository)</li>
                       </ul>
                     </li>
-                    <li><a href="http://ja.wordpress.org/files/2011/09/wapuu.png">PNG File (378×382 px)</a></li>
-                    <li><a href="http://ja.wordpress.org/files/2012/12/wapuu.pdf">Vector PDF File</a></li>
+                    <li><a href="https://ja.wordpress.org/files/2011/09/wapuu.png">PNG File (378×382 px)</a></li>
+                    <li><a href="https://ja.wordpress.org/files/2012/12/wapuu.pdf">Vector PDF File</a></li>
                 </ul>
 
                 <h2 id="add-archive">How To Add To Wapuu's Archives By Pull Request</h2>
@@ -114,7 +114,7 @@
         <div id="footer_wrap" class="outer">
             <footer class="inner">
                 <p class="copyright">Wapuu maintained by <a href="https://github.com/jawordpressorg">jawordpressorg</a></p>
-                <p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>
+                <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
             </footer>
         </div>
 

--- a/faq_en.html
+++ b/faq_en.html
@@ -13,7 +13,7 @@
     </head>
 
     <body>
-        <a href="http://jawordpressorg.github.io/wapuu/"><img style="position: absolute; top: 0; right: 0; border: 0; padding: 0; margin: 0; box-shadow: none;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+        <a href="https://github.com/jawordpressorg/wapuu/"><img style="position: absolute; top: 0; right: 0; border: 0; padding: 0; margin: 0; box-shadow: none;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
         <!-- HEADER -->
         <div id="header_wrap" class="outer">
             <header class="inner">

--- a/index.html
+++ b/index.html
@@ -658,7 +658,7 @@
         <div id="footer_wrap" class="outer">
             <footer class="inner">
                 <p class="copyright">Wapuu maintained by <a href="https://github.com/jawordpressorg">jawordpressorg</a></p>
-                <p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>
+                <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
             </footer>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </head>
 
     <body>
-        <a href="https://github.com/jawordpressorg/wapuu/fork"><img style="position: absolute; top: 0; right: 0; border: 0; padding: 0; margin: 0; box-shadow: none;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+        <a href="https://github.com/jawordpressorg/wapuu/"><img style="position: absolute; top: 0; right: 0; border: 0; padding: 0; margin: 0; box-shadow: none;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
         <!-- HEADER -->
         <div id="header_wrap" class="outer">
             <header class="inner">


### PR DESCRIPTION
Makes the FAQ Fork Me links link to the repository.

Also update various WordPress.org and Github links to use HTTPS.
